### PR TITLE
Fixed the system statistic user name display bug

### DIFF
--- a/xalgo_system/users/views.py
+++ b/xalgo_system/users/views.py
@@ -60,7 +60,7 @@ class SystemStatsView(TemplateView):
     def get_context_data(self, **kwargs: Any) -> Dict[str, Any]:
         context = super(SystemStatsView, self).get_context_data()
 
-        context["users"] = User.objects.all().only("name", "email")
+        context["users"] = User.objects.all().only("username", "email")
         context["rules"] = Rule.objects.all().only("rule_creator")
 
         return context


### PR DESCRIPTION
The name of the user on the statistic page was not displayed properly. It was displaying the username of the current login user.  Now the page displays the name accurately for each user